### PR TITLE
Store test reports and artifacts in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,8 @@ jobs:
       - run:
           name: Check test site is up
           command: ./.circleci/scripts/check-test-site-up.sh
-      - run: cd e2etests && gauge install && npm install && npm test
+      - run: cd e2etests && gauge install && gauge install xml-report && npm install && gauge run specs
       - store_artifacts:
-          path: reports
+          path: ./e2etests/reports/html-report/
+      - store_test_results:
+          path: ./e2etests/reports/xml-report/


### PR DESCRIPTION
As well as being displayed in the test results and artifacts tabs after
each build as expected, the test results are automatically fed into the
CircleCI Insights dashboard [1][2], which is pretty cool.

[1] https://circleci.com/build-insights/gh/agilepathway
[2] https://circleci.com/docs/2.0/insights/