### PR TITLE
Use Renovate to pin docker pulls to the digest

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,11 @@
 {
   "extends": [
     "config:base"
-  ]
+  ],
+  "dockerfile": {
+    "fileMatch": [
+      ".circleci/config.yml"
+    ],
+    "pinDigests": true
+  }
 }


### PR DESCRIPTION
This is so that the docker image used in the builds are immutable,
preventing potential subtle bugs that are very difficult to detect.

See:

https://renovate.whitesourcesoftware.com/blog/overcoming-dockers-mutable-image-tags/

https://docs.microsoft.com/en-us/archive/blogs/stevelasker/docker-tagging-best-practices-for-tagging-and-versioning-docker-images