### PR TITLE
Use immutable Docker tag for base gauge image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 executors:
   circleci-gauge-executor:
     docker:
-      - image: agilepathway/cimg-gauge:1.0.8
+      - image: agilepathway/cimg-gauge:1.0.8-CIRCLECI-49
 
 workflows:
   version: 2


### PR DESCRIPTION
The new tag we're pinning to is the semantic version (i.e. the gauge
version), followed by the circleci tag - which includes the circleci
build number.  Because the build number is unique for every build, it
means that we can pin to this tag knowing that the image will not change
in the future.

This also means that we don't need to pin to the digest to get
an immutable image.  The circleci build number is more meaningful than
the digest, making it easier to correlate data when needed.

See these articles on the dangers of mutable tags:
- https://stevelasker.blog/2018/03/01/docker-tagging-best-practices-for-tagging-and-versioning-docker-images/
- https://renovate.whitesourcesoftware.com/blog/overcoming-dockers-mutable-image-tags/
- https://medium.com/sroze/why-i-think-we-should-all-use-immutable-docker-images-9f4fdcb5212f