### PR TITLE
Remove version from workflow in CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ executors:
       - image: agilepathway/cimg-gauge:1.0.8-CIRCLECI-426
 
 workflows:
-  version: 2
   test:
     jobs:
       - shellcheck/check


### PR DESCRIPTION
As per:
https://discuss.circleci.com/t/circleci-2-1-config-overview/26057

> workflows no longer have a version number. Make sure to take the version key out of your workflows section or bad things will happen. The only version key in 2.1 is the top-level key.